### PR TITLE
[Dy2St][CINN] Fix `jit.to_static` usage to enable CINN as default backend

### DIFF
--- a/modulus/sym/domain/constraint/constraint.py
+++ b/modulus/sym/domain/constraint/constraint.py
@@ -101,20 +101,15 @@ class Constraint:
 
         # enable dy2st
         import os
+
         enable_jit = bool(os.getenv("to_static", "True") == "True") # Jit is enabled by default
-        enable_cinn = bool(os.getenv("FLAGS_use_cinn", "False") == "True") # CINN is disabled by default
         if enable_jit:
             from paddle import jit
-            from paddle import static
-            build_strategy = static.BuildStrategy()
-            build_strategy.build_cinn_pass = enable_cinn
-            self.model.forward = jit.to_static(full_graph=True, build_strategy=build_strategy)(self.model.forward)
-            logger.info(f"🍰 🍰 Using jit.to_static with FLAGS_use_cinn={enable_cinn} in Constraint.__init__ in {__file__}, to_static can be disabled by set 'to_static=False python example.py'")
-        elif enable_cinn:
-            raise RuntimeError(
-                f"Please set FLAGS_use_cinn=0 when 'to_static' is set to 0"
-            )
 
+            self.model.forward = jit.to_static(full_graph=True)(self.model.forward)
+            logger.info(
+                f"🍰 🍰 Using jit.to_static in Constraint.__init__ in {__file__}, to_static can be disabled by set 'to_static=False python example.py'"
+            )
 
     @property
     def input_names(self) -> List[Key]:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

在 modulus benchmark 项目里修改 `to_static` 使用，修改后和 Paddle develop flag 使用基本对齐

- 仅动转静：`to_static=True ENABLE_CINN_IN_DY2ST=0`
- 动转静+CINN：`to_static=True`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
