### PR TITLE
export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能

### DIFF
--- a/test_tipc/dynamic/anti_derivative-data_informed/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamic/anti_derivative-data_informed/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamic/chip_2d-chip_2d_solid_fluid_heat_transfer_heat/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamic/chip_2d-chip_2d_solid_fluid_heat_transfer_heat/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamic/helmholtz-helmholtz_hardBC/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamic/helmholtz-helmholtz_hardBC/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamic/taylor_green-taylor_green_causal/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamic/taylor_green-taylor_green_causal/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamicTostatic/chip_2d-chip_2d_solid_solid_heat_transfer/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamicTostatic/chip_2d-chip_2d_solid_solid_heat_transfer/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamicTostatic/ode_spring_mass-spring_mass_solver/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamicTostatic/ode_spring_mass-spring_mass_solver/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改

--- a/test_tipc/dynamicTostatic/seismic_wave-wave_2d/benchmark_common/run_benchmark.sh
+++ b/test_tipc/dynamicTostatic/seismic_wave-wave_2d/benchmark_common/run_benchmark.sh
@@ -43,6 +43,7 @@ function _analysis_log(){
 }
 
 function _train(){
+    export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能，benchmark监控打开此flag
     echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
 
 #   以下为通用执行命令，无特殊可不用修改


### PR DESCRIPTION
export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能

<!-- markdownlint-disable MD013-->
benchmark

## Description
export NVIDIA_TF32_OVERRIDE=1 #Paddle的PR#75907默认关闭此flag，影响性能



## Dependencies

<!-- Call out any new dependencies needed if any -->